### PR TITLE
add gcp required apis to metadata/defaults and descriptions to metadata variables

### DIFF
--- a/.tb/activator_metadata.yml
+++ b/.tb/activator_metadata.yml
@@ -12,14 +12,21 @@ ci:
 cd: 
   - Jenkins
 mandatoryVariables:
-  - name: standard_subnetwork
-    type: string
   - name: zone
     type: tb_zone
-  - name: host_project_id
-    type: string
+    description: General zone of the project, example 'europe-west2-b'
+    default: europe-west2-b
   - name: region
     type: tb_region
+    description: General region of the project, example 'europe-west2'
+    default: europe-west2
 optionalVariables:
   - name: vms_size
     type: tb_vms_size
+    description: size of the virtual machine to be created in GB
+    default: 20
+gcpApisRequired:
+  - compute.googleapis.com
+  - servicemanagement.googleapis.com
+  - cloudresourcemanager.googleapis.com
+  - storage-api.googleapis.com

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,51 +2,61 @@ pipeline
 {
     agent any
     environment {
-       def DockerHome = tool name: 'docker', type: 'org.jenkinsci.plugins.docker.commons.tools.DockerTool'
-       def DockerCMD = "${DockerHome}/bin/docker"
-       def activator_params = "${activator_params}"
+        def DockerHome = tool name: 'docker', type: 'org.jenkinsci.plugins.docker.commons.tools.DockerTool'
+        def DockerCMD = "${DockerHome}/bin/docker"
+        def activator_params = "${activator_params}"
     }
     stages {
-        stage('Build Activator Docker Image')  {
-          steps {
-             sh "cp $GOOGLE_APPLICATION_CREDENTIALS service-account.json"
-             sh "cat service-account.json"
-             sh "echo ${activator_params}"
-             sh "echo \$activator_params"
-             sh "echo \$activator_params > activator_params.json"
-             sh "ls -ltr docker/"
-             sh "${DockerCMD} build -f docker/Dockerfile -t tb-test:$BUILD_NUMBER ."
-             sh "${DockerCMD} image ls"
-          }
-        }
-        stage('Run Activator Docker Image') {
-          steps {
-              sh "${DockerCMD} run -t -d --name base-activator$BUILD_NUMBER tb-test:$BUILD_NUMBER"
-              sh "${DockerCMD} ps"
-           }
-        }
-        stage('Activator Terraform init validate plan') {
-           steps {
-              sh "ls -ltr"
-              sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform init deployment_code"
-              sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform validate deployment_code/"
-              sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform plan -out activator-plan -var='host_project_id=$projectid' deployment_code/"
-           }
+        stage('Activate GCP Service Account and Set Project') {
+            steps {
+                sh "gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS"
+                sh "gcloud config set project $projectid"
+            }
         }
         stage('Enable Required Google APIs') {
-           steps {
-              sh "gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS"
-              sh "gcloud config set project $projectid"
-              sh "gcloud services enable compute.googleapis.com"
-              sh "gcloud services enable servicemanagement.googleapis.com"
-              sh "gcloud services enable cloudresourcemanager.googleapis.com"
-              sh "gcloud services enable storage-api.googleapis.com"
-           }
+            steps {
+                script {
+                    def activator_metadata = readYaml file: ".tb/activator_metadata.yml"
+                    echo "activator_metadata map ${activator_metadata}"
+                    def gcpApisRequired = activator_metadata.get('gcpApisRequired')
+                    if (gcpApisRequired) {
+                        gcpApisRequired.each {
+                            echo "Enabling $it"
+                            sh "gcloud services enable $it"
+                        }
+                    }
+                }
+            }
+        }
+        stage('Build Activator Docker Image') {
+            steps {
+                sh "cp $GOOGLE_APPLICATION_CREDENTIALS service-account.json"
+                sh "cat service-account.json"
+                sh "echo \$activator_params"
+                sh "echo \$activator_params > activator_params.json"
+                sh "ls -ltr docker/"
+                sh "${DockerCMD} build -f docker/Dockerfile -t tb-test:$BUILD_NUMBER ."
+                sh "${DockerCMD} image ls"
+            }
+        }
+        stage('Run Activator Docker Image') {
+            steps {
+                sh "${DockerCMD} run -t -d --name base-activator$BUILD_NUMBER tb-test:$BUILD_NUMBER"
+                sh "${DockerCMD} ps"
+            }
+        }
+        stage('Activator Terraform init validate plan') {
+            steps {
+                sh "ls -ltr"
+                sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform init deployment_code"
+                sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform validate deployment_code/"
+                sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform plan -out activator-plan -var='host_project_id=$projectid' deployment_code/"
+            }
         }
         stage('Activator Infra Deploy') {
-           steps {
-              sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform apply  --auto-approve activator-plan"
-           }
-         }
-       }
+            steps {
+                sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform apply  --auto-approve activator-plan"
+            }
+        }
+    }
 }


### PR DESCRIPTION
add defaults and descriptions to metadata variables
add gcpRequiredApis to metadata
refactor Jenkinsfile to get apis from metadata file (this to be moved to DAC/Jenkins pipeline job later)

covers issues #20 and #15 