### PR TITLE
Define and export outputs for activator

### DIFF
--- a/.tb/activator_metadata.yml
+++ b/.tb/activator_metadata.yml
@@ -49,14 +49,13 @@ environmentVariables:
     type: string
     description: Shared VPC Project ID. Not used in deployment script
 # these variables represent the outputs of the activator. For ease of definition the names should match the output names in the terraform outputs.tf file
-outputVariables
+outputVariables:
   - name: storage_bucket_url
     type: string
     description: Name of the GCP cloud storage bucket created
   - name: virtual_machine_name
     type: string
     description: Name of the GCP compute engine virtual machine created
-
 # GCP APIs that need to be enabled on the GCP project in order for the activator to deploy to it
 gcpApisRequired:
   - compute.googleapis.com

--- a/.tb/activator_metadata.yml
+++ b/.tb/activator_metadata.yml
@@ -48,6 +48,15 @@ environmentVariables:
   - name: shared_vpc_project_id
     type: string
     description: Shared VPC Project ID. Not used in deployment script
+# these variables represent the outputs of the activator. For ease of definition the names should match the output names in the terraform outputs.tf file
+outputVariables
+  - name: storage_bucket_url
+    type: string
+    description: Name of the GCP cloud storage bucket created
+  - name: virtual_machine_name
+    type: string
+    description: Name of the GCP compute engine virtual machine created
+
 # GCP APIs that need to be enabled on the GCP project in order for the activator to deploy to it
 gcpApisRequired:
   - compute.googleapis.com

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,12 @@ pipeline
         def environment_params = "${environment_params}"
     }
     stages {
+        stage('Create file in workspace') {
+            steps {
+                echo "writing  text file in workspace"
+                sh "cat \"test text \" >  test.txt"
+            }
+        }
         stage('Activate GCP Service Account and Set Project') {
             steps {
                 sh "gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,10 @@ pipeline
             steps {
                 echo "writing  text file in workspace"
                 sh "echo \"test text \" >  test.txt"
-                terraform_output = sh (returnStdout: true, script: 'cat test.txt').trim()
-                echo "Terraform output : ${terraform_output}"
+                script {
+                    terraform_output = sh (returnStdout: true, script: 'cat test.txt').trim()
+                    echo "Terraform output : ${terraform_output}"
+                }
             }
         }
         stage('Activate GCP Service Account and Set Project') {
@@ -69,8 +71,10 @@ pipeline
             steps {
                 sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform apply  --auto-approve activator-plan"
                 sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform output -json > terraform_output.json"
+                script {
                 terraform_output = sh (returnStdout: true, script: 'cat terraform_output.json').trim()
                 echo "Terraform output : ${terraform_output}"
+                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline
         stage('Create file in workspace') {
             steps {
                 echo "writing  text file in workspace"
-                sh "cat \"test text \" >  test.txt"
+                sh "echo \"test text \" >  test.txt"
             }
         }
         stage('Activate GCP Service Account and Set Project') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,11 +12,12 @@ pipeline
         stage('Create file in workspace') {
             steps {
                 echo "writing  text file in workspace"
-                sh "echo \"test text \" >  test.txt"
+//                 sh "echo \"test text \" >  activator_outputs.json"
+                sh "echo ${activator_params} > activator_outputs.json"
                 script {
-                    terraform_output = sh (returnStdout: true, script: 'cat test.txt').trim()
+                    terraform_output = sh (returnStdout: true, script: 'cat activator_outputs.json').trim()
                     echo "Terraform output : ${terraform_output}"
-                    archiveArtifacts artifacts: 'test.txt'
+                    archiveArtifacts artifacts: 'activator_outputs.json'
                 }
             }
         }
@@ -71,11 +72,11 @@ pipeline
         stage('Activator Infra Deploy') {
             steps {
                 sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform apply  --auto-approve activator-plan"
-                sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform output -json > terraform_output.json"
+                sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform output -json > activator_outputs.json"
                 script {
                     terraform_output = sh (returnStdout: true, script: 'cat terraform_output.json').trim()
                     echo "Terraform output : ${terraform_output}"
-                    archiveArtifacts artifacts: 'terraform_output.json'
+                    archiveArtifacts artifacts: 'activator_outputs.json'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline
                 script {
                     terraform_output = sh (returnStdout: true, script: 'cat test.txt').trim()
                     echo "Terraform output : ${terraform_output}"
+                    archiveArtifacts artifacts: 'test.txt'
                 }
             }
         }
@@ -72,8 +73,9 @@ pipeline
                 sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform apply  --auto-approve activator-plan"
                 sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform output -json > terraform_output.json"
                 script {
-                terraform_output = sh (returnStdout: true, script: 'cat terraform_output.json').trim()
-                echo "Terraform output : ${terraform_output}"
+                    terraform_output = sh (returnStdout: true, script: 'cat terraform_output.json').trim()
+                    echo "Terraform output : ${terraform_output}"
+                    archiveArtifacts artifacts: 'terraform_output.json'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,8 @@ pipeline
             steps {
                 echo "writing  text file in workspace"
 //                 sh "echo \"test text \" >  activator_outputs.json"
-                sh "echo ${activator_params} > activator_outputs.json"
+//                 sh "echo ${activator_params} > activator_outputs.json"
+                sh "printf \"%s\" ${activator_params} > activator_outputs.json"
                 script {
                     terraform_output = sh (returnStdout: true, script: 'cat activator_outputs.json').trim()
                     echo "Terraform output : ${terraform_output}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,7 @@ pipeline
         stage('Activator Infra Deploy') {
             steps {
                 sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform apply  --auto-approve activator-plan"
+                sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform output -json > terraform_output.json"
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,12 +6,15 @@ pipeline
         def DockerCMD = "${DockerHome}/bin/docker"
         def activator_params = "${activator_params}"
         def environment_params = "${environment_params}"
+        def terraform_output = ""
     }
     stages {
         stage('Create file in workspace') {
             steps {
                 echo "writing  text file in workspace"
                 sh "echo \"test text \" >  test.txt"
+                terraform_output = sh (returnStdout: true, script: 'cat test.txt').trim()
+                echo "Terraform output : ${terraform_output}"
             }
         }
         stage('Activate GCP Service Account and Set Project') {
@@ -66,6 +69,8 @@ pipeline
             steps {
                 sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform apply  --auto-approve activator-plan"
                 sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform output -json > terraform_output.json"
+                terraform_output = sh (returnStdout: true, script: 'cat terraform_output.json').trim()
+                echo "Terraform output : ${terraform_output}"
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,19 +9,6 @@ pipeline
         def terraform_output = ""
     }
     stages {
-        stage('Create file in workspace') {
-            steps {
-                echo "writing  text file in workspace"
-//                 sh "echo \"test text \" >  activator_outputs.json"
-//                 sh "echo ${activator_params} > activator_outputs.json"
-                sh "printf \"%s\" ${activator_params} > activator_outputs.json"
-                script {
-                    terraform_output = sh (returnStdout: true, script: 'cat activator_outputs.json').trim()
-                    echo "Terraform output : ${terraform_output}"
-                    archiveArtifacts artifacts: 'activator_outputs.json'
-                }
-            }
-        }
         stage('Activate GCP Service Account and Set Project') {
             steps {
                 sh "gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS"
@@ -75,7 +62,7 @@ pipeline
                 sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform apply  --auto-approve activator-plan"
                 sh "${DockerCMD} exec base-activator$BUILD_NUMBER terraform output -json > activator_outputs.json"
                 script {
-                    terraform_output = sh (returnStdout: true, script: 'cat terraform_output.json').trim()
+                    terraform_output = sh (returnStdout: true, script: 'cat activator_outputs.json').trim()
                     echo "Terraform output : ${terraform_output}"
                     archiveArtifacts artifacts: 'activator_outputs.json'
                 }

--- a/deployment/outputs.tf
+++ b/deployment/outputs.tf
@@ -1,0 +1,24 @@
+# Copyright 2019 The Tranquility Base Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "storage_bucket" {
+  description = "storage bucket created"
+  value       = google_storage_bucket.landing_data
+}
+
+output "virtual_machine" {
+  description = "virtual machine created"
+  value       = google_compute_instance.vm_instance
+}
+

--- a/deployment/outputs.tf
+++ b/deployment/outputs.tf
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-output "storage_bucket" {
+output "storage_bucket_url" {
   description = "storage bucket created"
-  value       = google_storage_bucket.landing_data
+  value       = google_storage_bucket.landing_data.url
 }
 
 output "virtual_machine" {
   description = "virtual machine created"
-  value       = google_compute_instance.vm_instance
+  value       = google_compute_instance.vm_instance.name
 }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,11 @@ COPY activator_params.json activator_params.json
 RUN ["/bin/bash","-c", "cat activator_params.json | jq '.' > deployment_code/activator_params.json"]
 RUN cat deployment_code/activator_params.json
 
+# process environment variables json
+COPY environment_params.json environment_params.json
+RUN ["/bin/bash","-c", "cat environment_params.json | jq '.' > deployment_code/environment_params.json"]
+RUN cat deployment_code/environment_params.json
+
 RUN ls deployment_code
 
 RUN mkdir /opt/app/ && mkdir /opt/app/data


### PR DESCRIPTION
Contains changes for 
#30 
#31 
#32

Define output variables in activator metadata
Define terraform outputs matching these output variables
Activator creates Jenkins artifact called activator_outputs,json containing terraform outputs
The activator_outputs,json artifact can be retrieved by DAC when it gets the activator job build result.

example artifact created:
```
{
  "storage_bucket_url": {
    "sensitive": false,
    "type": "string",
    "value": "gs://development-3klf8i-8a8gyat1-landing-data-bucket-mssb-sandbox"
  },
  "virtual_machine": {
    "sensitive": false,
    "type": "string",
    "value": "vm1"
  }
}
```